### PR TITLE
test: Ensure GitHub Actions runs fail when tests fail

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,6 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+set -e
+set -o pipefail
+set -x
+set -u
+
 SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="$SCRIPTS_DIRECTORY/.."
 TESTS_DIRECTORY="$ROOT_DIRECTORY/tests"

--- a/tests/common.py
+++ b/tests/common.py
@@ -79,6 +79,7 @@ class Repository(object):
         self.directory = tempfile.TemporaryDirectory()
         self.directory.__enter__()
         self.init()
+        self.set_user("Someone", "someone@example.com")
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/tests/common.py
+++ b/tests/common.py
@@ -118,6 +118,13 @@ class Repository(object):
         lines = [line for line in lines if line]
         return lines
 
+    def config(self, name, value):
+        return self.git(["config", name, value])
+
+    def set_user(self, name, email):
+        self.config("user.name", name)
+        self.config("user.email", email)
+
     def perform(self, operations):
         for operation in operations:
             operation.perform(self)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,13 +37,11 @@ class CLITestCase(unittest.TestCase):
 
     def test_create_repository(self):
         with Repository() as repository:
-            repository.set_user("Someone", "someone@example.com")
             self.assertTrue(os.path.isdir(repository.path))
             self.assertTrue(os.path.isdir(os.path.join(repository.path, ".git")))
 
     def test_add_commit(self):
         with Repository() as repository:
-            repository.set_user("Someone", "someone@example.com")
             repository.commit("commit one", allow_empty=True)
             self.assertEqual(repository.rev_list("HEAD", count=True), 1)
             repository.commit("commit two", allow_empty=True)
@@ -51,7 +49,6 @@ class CLITestCase(unittest.TestCase):
 
     def test_batch_commit(self):
         with Repository() as repository:
-            repository.set_user("Someone", "someone@example.com")
             repository.perform([
                 EmptyCommit("commit one"),
                 EmptyCommit("commit two"),
@@ -60,7 +57,6 @@ class CLITestCase(unittest.TestCase):
 
     def test_tag(self):
         with Repository() as repository:
-            repository.set_user("Someone", "someone@example.com")
             repository.commit("commit", allow_empty=True)
             self.assertEqual(repository.rev_list("HEAD", count=True), 1)
             self.assertEqual(repository.tag(), [])
@@ -69,7 +65,6 @@ class CLITestCase(unittest.TestCase):
 
     def test_operations(self):
         with Repository() as repository:
-            repository.set_user("Someone", "someone@example.com")
             repository.perform([
                 EmptyCommit("initial commit"),
                 Tag("0.1.0"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,11 +37,13 @@ class CLITestCase(unittest.TestCase):
 
     def test_create_repository(self):
         with Repository() as repository:
+            repository.set_user("Someone", "someone@example.com")
             self.assertTrue(os.path.isdir(repository.path))
             self.assertTrue(os.path.isdir(os.path.join(repository.path, ".git")))
 
     def test_add_commit(self):
         with Repository() as repository:
+            repository.set_user("Someone", "someone@example.com")
             repository.commit("commit one", allow_empty=True)
             self.assertEqual(repository.rev_list("HEAD", count=True), 1)
             repository.commit("commit two", allow_empty=True)
@@ -49,6 +51,7 @@ class CLITestCase(unittest.TestCase):
 
     def test_batch_commit(self):
         with Repository() as repository:
+            repository.set_user("Someone", "someone@example.com")
             repository.perform([
                 EmptyCommit("commit one"),
                 EmptyCommit("commit two"),
@@ -57,6 +60,7 @@ class CLITestCase(unittest.TestCase):
 
     def test_tag(self):
         with Repository() as repository:
+            repository.set_user("Someone", "someone@example.com")
             repository.commit("commit", allow_empty=True)
             self.assertEqual(repository.rev_list("HEAD", count=True), 1)
             self.assertEqual(repository.tag(), [])
@@ -65,6 +69,7 @@ class CLITestCase(unittest.TestCase):
 
     def test_operations(self):
         with Repository() as repository:
+            repository.set_user("Someone", "someone@example.com")
             repository.perform([
                 EmptyCommit("initial commit"),
                 Tag("0.1.0"),


### PR DESCRIPTION
This change also fixes the failing tests that we were missing prior to setting the correct flags on the test script by ensuring there's a user configured for the test repository.