### PR TITLE
test: Check that multiple changes only yield one version number increment

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,4 +30,4 @@ TESTS_DIRECTORY="$ROOT_DIRECTORY/tests"
 
 pushd "$TESTS_DIRECTORY" > /dev/null
 python3 -m unittest discover --verbose
-popd
+popd > /dev/null

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,13 +22,12 @@
 
 set -e
 set -o pipefail
-set -x
 set -u
 
 SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="$SCRIPTS_DIRECTORY/.."
 TESTS_DIRECTORY="$ROOT_DIRECTORY/tests"
 
-pushd "$TESTS_DIRECTORY"
+pushd "$TESTS_DIRECTORY" > /dev/null
 python3 -m unittest discover --verbose
 popd

--- a/tests/common.py
+++ b/tests/common.py
@@ -90,7 +90,10 @@ class Repository(object):
             kwargs = {}
             if env is not None:
                 kwargs["env"] = env
-            return subprocess.check_output(command, **kwargs).decode("utf-8")
+            result = subprocess.run(command, capture_output=True, **kwargs)
+            result.check_returncode()
+            return result.stdout.decode("utf-8")
+
 
     def git(self, arguments):
         return self.run(["git"] + arguments)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,9 +32,6 @@ common.configure_path()
 
 class CLITestCase(unittest.TestCase):
 
-    def test_true(self):
-        self.assertTrue(True)
-
     def test_create_repository(self):
         with Repository() as repository:
             self.assertTrue(os.path.isdir(repository.path))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,29 @@ class CLITestCase(unittest.TestCase):
             ])
             self.assertEqual(repository.changes_current_version(), "1.0.0")
 
+    def test_multiple_changes_yield_single_increment(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("inital commit"),
+                Tag("0.1.0")
+            ])
+            self.assertEqual(repository.changes_current_version(), "0.1.0")
+            repository.perform([
+                EmptyCommit("fix: this fix should update the patch version"),
+                EmptyCommit("fix: this fix should not update the patch version"),
+            ])
+            self.assertEqual(repository.changes_current_version(), "0.1.1")
+            repository.perform([
+                EmptyCommit("feat: this feat should update the minor version"),
+                EmptyCommit("feat: this feat should not update the minor version"),
+            ])
+            self.assertEqual(repository.changes_current_version(), "0.2.0")
+            repository.perform([
+                EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should update the minor version"),
+                EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should not update the minor version"),
+            ])
+            self.assertEqual(repository.changes_current_version(), "1.0.0")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change also includes a drive-by fix to quiet the command warnings by capturing stderr.