### PR TITLE
test: Initial tests for current-notes

### DIFF
--- a/changes
+++ b/changes
@@ -192,12 +192,11 @@ TYPE_TO_SECTION = {
 def format_messages(messages, section):
     result = ""
     result = result + f"**{section}**\n\n"
-    for message in messages:
+    for message in reversed(messages):
         result = result + f"- {message.description}"
         if message.scope is not None:
             result = result + f" ({message.scope})"
         result = result + "\n"
-    result = result + "\n"
     return result
 
 
@@ -206,11 +205,12 @@ def format_changes(changes):
     sections = collections.defaultdict(list)
     for commit in changes:
         sections[TYPE_TO_SECTION[commit.message.type]].append(commit.message)
+    content = []
     if "Changes" in sections:
-        result = result + format_messages(sections["Changes"], "Changes")
+        content.append(format_messages(sections["Changes"], "Changes"))
     if "Fixes" in sections:
-        result = result + format_messages(sections["Fixes"], "Fixes")
-    return result
+        content.append(format_messages(sections["Fixes"], "Fixes"))
+    return "\n".join(content)
 
 
 def format_release(release):

--- a/tests/common.py
+++ b/tests/common.py
@@ -147,6 +147,12 @@ class Repository(object):
     def changes_released_version(self):
         return self.changes(["released-version"]).strip()
 
+    def current_notes(self):
+        return self.changes(["current-notes"])
+
+    def changes_release(self):
+        return self.changes(["release"])
+
     @property
     def path(self):
         return self.directory.name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,7 @@ class CLITestCase(unittest.TestCase):
     def test_released_version(self):
         with Repository() as repository:
             repository.perform([
-                EmptyCommit("initia commit"),
+                EmptyCommit("initial commit"),
                 Tag("2.1.3"),
             ])
             self.assertEqual(repository.changes_released_version(), "2.1.3")
@@ -153,6 +153,56 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should not affect the released version"),
             ])
             self.assertEqual(repository.changes_released_version(), "2.1.3")
+
+    def test_current_notes(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("initial commit"),
+                Tag("1.0.0")
+            ])
+            self.assertEqual(repository.current_notes(), "")
+            repository.perform([
+                EmptyCommit("fix: Doesn't crash"),
+                EmptyCommit("fix: Works"),
+            ])
+            self.assertEqual(repository.current_notes(),
+"""**Fixes**
+
+- Doesn't crash
+- Works
+""")
+            repository.perform([
+                EmptyCommit("feat: New Shiny"),
+            ])
+            self.assertEqual(repository.current_notes(),
+"""**Changes**
+
+- New Shiny
+
+**Fixes**
+
+- Doesn't crash
+- Works
+""")
+            repository.changes_release()
+            self.assertEqual(repository.current_notes(),
+"""**Changes**
+
+- New Shiny
+
+**Fixes**
+
+- Doesn't crash
+- Works
+""")
+            repository.perform([
+                EmptyCommit("feat: More Shiny"),
+            ])
+            self.assertEqual(repository.current_notes(),
+"""**Changes**
+
+- More Shiny
+""")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a drive-by fix to the whitespace in the release notes, and ensures the entires in the release notes are chronologically ordered.