### PR TITLE
fix: Add a newline between different releases in all changes

### DIFF
--- a/changes
+++ b/changes
@@ -231,9 +231,8 @@ def format_release(release):
 
 
 def format_releases(releases):
-    result = ""
-    for release in releases:
-        result = result + format_release(release)
+    content = [format_release(release) for release in releases]
+    return "\n".join(content)
     return result
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -70,6 +70,12 @@ class Tag(object):
         repository.tag(self.tagname)
 
 
+class Release(object):
+
+    def perform(self, repository):
+        repository.changes_release()
+
+
 class Repository(object):
 
     def __init__(self):
@@ -152,6 +158,9 @@ class Repository(object):
 
     def changes_release(self):
         return self.changes(["release"])
+
+    def changes_all_changes(self):
+        return self.changes(["all-changes"])
 
     @property
     def path(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,10 +225,7 @@ class CLITestCase(unittest.TestCase):
 - More Shiny
 """)
 
-# TODO: Support --skip-unreleased
-#       --only-released
-
-    def test_release_notes(self):
+    def test_all_changes(self):
         with Repository() as repository:
             repository.perform([
                 EmptyCommit("feat: Initial commit"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ import unittest
 
 import common
 
-from common import Commit, EmptyCommit, Repository, Tag
+from common import Commit, EmptyCommit, Release, Repository, Tag
 
 common.configure_path()
 
@@ -223,6 +223,48 @@ class CLITestCase(unittest.TestCase):
 """**Changes**
 
 - More Shiny
+""")
+
+# TODO: Support --skip-unreleased
+#       --only-released
+
+    def test_release_notes(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: Initial commit"),
+                Release(),
+                EmptyCommit("fix: Fix something"),
+                EmptyCommit("fix: Fix something else"),
+                Release(),
+                EmptyCommit("fix!: Fix something breaking compatibility"),
+                Release(),
+                EmptyCommit("feat: Unreleased feature"),
+            ])
+            self.assertEqual(repository.changes_all_changes(),
+"""# 1.1.0 (Unreleased)
+
+**Changes**
+
+- Unreleased feature
+
+# 1.0.0
+
+**Fixes**
+
+- Fix something breaking compatibility
+
+# 0.1.1
+
+**Fixes**
+
+- Fix something
+- Fix something else
+
+# 0.1.0
+
+**Changes**
+
+- Initial commit
 """)
 
 


### PR DESCRIPTION
When the different release sections were concatenated, no newline was being added between them, leading to incorrect markdown.

This change also introduces an integration test for the `all-changes` sub-command.