### PR TITLE
feat!: Consolidate the version commands

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -310,13 +310,17 @@ def resolve_scope(options):
         return None
 
 
-@cli.command("current-version", help="output the current version as determined by taking the the most recent version tag and applying any subsequent changes; if there have been no changes since the most recent version tag, this will output the version of the most recent tag", arguments=[
+@cli.command("version", help="output the current version as determined by taking the the most recent version tag and applying any subsequent changes; if there have been no changes since the most recent version tag, this will output the version of the most recent tag", arguments=[
     cli.Argument("--scope", help="scope to be used in tags and commit messages"),
+    cli.Argument("--released", action="store_true", default=False, help="scope to be used in tags and commit messages"),
 ])
-def command_current_version(options):
+def command_version(options):
     history = History(scope=resolve_scope(options))
     releases = history.releases
-    print(releases[0].version)
+    release = releases[0]
+    if options.released:
+        release = next(release for release in releases if release.has_tag)
+    print(release.version)
 
 
 @cli.command("current-notes", help="formatted output of all unreleased changes, or changes in the released version if there are no unreleased changes", arguments=[
@@ -326,16 +330,6 @@ def command_current_notes(options):
     history = History(scope=resolve_scope(options))
     releases = history.releases
     print(format_changes(releases[0].changes), end="")
-
-
-@cli.command("released-version", help="released version number as given by the most recent git version tag", arguments=[
-    cli.Argument("--scope", help="scope to be used in tags and commit messages"),
-])
-def command_released_version(options):
-    history = History(scope=resolve_scope(options))
-    releases = history.releases
-    active_release = next(release for release in releases if release.has_tag)
-    print(active_release.version)
 
 
 @cli.command("release", help="a", arguments=[

--- a/tests/common.py
+++ b/tests/common.py
@@ -162,14 +162,13 @@ class Repository(object):
         environment["PATH"] = environment["PATH"] + ":" + ROOT_DIRECTORY
         return self.run(["changes"] + arguments, env=environment)
 
-    def changes_current_version(self, scope=None):
-        arguments = ["current-version"]
+    def changes_version(self, scope=None, released=False):
+        arguments = ["version"]
         if scope is not None:
             arguments.extend(["--scope", scope])
+        if released:
+            arguments.extend(["--released"])
         return self.changes(arguments).strip()
-
-    def changes_released_version(self):
-        return self.changes(["released-version"]).strip()
 
     def current_notes(self):
         return self.changes(["current-notes"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("initial commit"),
             ])
-            self.assertEqual(repository.changes(["current-version"]), "0.0.0\n")
+            self.assertEqual(repository.changes(["version"]), "0.0.0\n")
 
     def test_current_version(self):
         with Repository() as repository:
@@ -83,27 +83,27 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("inital commit"),
                 Tag("0.2.0")
             ])
-            self.assertEqual(repository.changes_current_version(), "0.2.0")
+            self.assertEqual(repository.changes_version(), "0.2.0")
             repository.perform([
                 EmptyCommit("ignored commit"),
             ])
-            self.assertEqual(repository.changes_current_version(), "0.2.0")
+            self.assertEqual(repository.changes_version(), "0.2.0")
             repository.perform([
                 EmptyCommit("fix: this fix should update the patch version"),
             ])
-            self.assertEqual(repository.changes_current_version(), "0.2.1")
+            self.assertEqual(repository.changes_version(), "0.2.1")
             repository.perform([
                 EmptyCommit("feat: this feature should update the minor verison"),
             ])
-            self.assertEqual(repository.changes_current_version(), "0.3.0")
+            self.assertEqual(repository.changes_version(), "0.3.0")
             repository.perform([
                 EmptyCommit("BREAKING CHANGE: this break should update the major verison"),
             ])
-            self.assertEqual(repository.changes_current_version(), "1.0.0")
+            self.assertEqual(repository.changes_version(), "1.0.0")
 
     def test_current_version_no_changes(self):
         with Repository() as repository:
-            self.assertEqual(repository.changes_current_version(), "0.0.0")
+            self.assertEqual(repository.changes_version(), "0.0.0")
 
     def test_current_version_multiple_changes_yield_single_increment(self):
         with Repository() as repository:
@@ -111,22 +111,22 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("inital commit"),
                 Tag("0.1.0")
             ])
-            self.assertEqual(repository.changes_current_version(), "0.1.0")
+            self.assertEqual(repository.changes_version(), "0.1.0")
             repository.perform([
                 EmptyCommit("fix: this fix should update the patch version"),
                 EmptyCommit("fix: this fix should not update the patch version"),
             ])
-            self.assertEqual(repository.changes_current_version(), "0.1.1")
+            self.assertEqual(repository.changes_version(), "0.1.1")
             repository.perform([
                 EmptyCommit("feat: this feat should update the minor version"),
                 EmptyCommit("feat: this feat should not update the minor version"),
             ])
-            self.assertEqual(repository.changes_current_version(), "0.2.0")
+            self.assertEqual(repository.changes_version(), "0.2.0")
             repository.perform([
                 EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should update the minor version"),
                 EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should not update the minor version"),
             ])
-            self.assertEqual(repository.changes_current_version(), "1.0.0")
+            self.assertEqual(repository.changes_version(), "1.0.0")
 
     def test_current_version_with_scope(self):
         with Repository() as repository:
@@ -134,9 +134,9 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit"),
                 Tag("a_1.0.0"),
             ])
-            self.assertEqual(repository.changes_current_version(), "0.0.0")
-            self.assertEqual(repository.changes_current_version(scope="a"), "1.0.0")
-            self.assertEqual(repository.changes_current_version(scope="b"), "0.0.0")
+            self.assertEqual(repository.changes_version(), "0.0.0")
+            self.assertEqual(repository.changes_version(scope="a"), "1.0.0")
+            self.assertEqual(repository.changes_version(scope="b"), "0.0.0")
 
 
     def test_current_version_with_legacy_scope(self):
@@ -145,9 +145,9 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit"),
                 Tag("a_1.0.0"),
             ])
-            self.assertEqual(repository.changes(["current-version"]), "0.0.0\n")
-            self.assertEqual(repository.changes(["--scope", "a", "current-version"]), "1.0.0\n")
-            self.assertEqual(repository.changes(["--scope", "b", "current-version"]), "0.0.0\n")
+            self.assertEqual(repository.changes(["version"]), "0.0.0\n")
+            self.assertEqual(repository.changes(["--scope", "a", "version"]), "1.0.0\n")
+            self.assertEqual(repository.changes(["--scope", "b", "version"]), "0.0.0\n")
 
 
     def test_exclamation_mark_indicates_breaking_change(self):
@@ -155,17 +155,17 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat!: Breaking feat should increment major version"),
             ])
-            self.assertEqual(repository.changes_current_version(), "1.0.0")
+            self.assertEqual(repository.changes_version(), "1.0.0")
             repository.changes_release()
             repository.perform([
                 EmptyCommit("fix!: Breaking fix should increment major version"),
             ])
-            self.assertEqual(repository.changes_current_version(), "2.0.0")
+            self.assertEqual(repository.changes_version(), "2.0.0")
             repository.perform([
                 EmptyCommit("wibble!: Unknown breaking type should do nothing"),
                 EmptyCommit("ci!: Unknown ignored type should do nothing"),
             ])
-            self.assertEqual(repository.changes_current_version(), "2.0.0")
+            self.assertEqual(repository.changes_version(), "2.0.0")
 
     def test_released_version_raw_output(self):
         with Repository() as repository:
@@ -173,7 +173,7 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit"),
                 Tag("1.6.12"),
             ])
-            self.assertEqual(repository.changes(["released-version"]), "1.6.12\n")
+            self.assertEqual(repository.changes(["version", "--released"]), "1.6.12\n")
 
     def test_released_version_no_tag_fails(self):
         with Repository() as repository:
@@ -189,13 +189,13 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit"),
                 Tag("2.1.3"),
             ])
-            self.assertEqual(repository.changes_released_version(), "2.1.3")
+            self.assertEqual(repository.changes_version(released=True), "2.1.3")
             repository.perform([
                 EmptyCommit("fix: this fix should not affect the released version"),
                 EmptyCommit("feat: this feat should not affect the released version"),
                 EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should not affect the released version"),
             ])
-            self.assertEqual(repository.changes_released_version(), "2.1.3")
+            self.assertEqual(repository.changes_version(released=True), "2.1.3")
 
     def test_release_fails_empty_repository(self):
         with Repository() as repository:


### PR DESCRIPTION
The number of commands has been getting confusing. This change starts the work to consolidate them into just a few commands by merging the `released-version` and `current-version` commands into a single `version` command which can be extended in the future.

See https://github.com/jbmorley/changes/issues/39.