### PR TITLE
fix!: Remove 'BREAKING CHANGE' as a commit type

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -39,7 +39,6 @@ logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="[%
 
 
 class Type(enum.Enum):
-    BREAKING_CHANGE = "BREAKING CHANGE"
     CI = "ci"
     DOCUMENTATION = "docs"
     FEATURE = "feat"
@@ -48,7 +47,6 @@ class Type(enum.Enum):
 
 
 OPERATIONS = {
-    Type.BREAKING_CHANGE: lambda commit, version: version.bump_major(),
     Type.CI: None,
     Type.DOCUMENTATION: None,
     Type.FEATURE: lambda commit, version: version.bump_minor(),
@@ -58,7 +56,6 @@ OPERATIONS = {
 
 
 TYPE_TO_SECTION = {
-    Type.BREAKING_CHANGE: "Changes",
     Type.CI: "Ignore",
     Type.DOCUMENTATION: "Ignore",
     Type.FEATURE: "Changes",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,7 @@ class CLITestCase(unittest.TestCase):
             ])
             self.assertEqual(repository.changes_version(), "0.3.0")
             repository.perform([
-                EmptyCommit("BREAKING CHANGE: this break should update the major verison"),
+                EmptyCommit("feat!: this break should update the major verison"),
             ])
             self.assertEqual(repository.changes_version(), "1.0.0")
 
@@ -123,8 +123,8 @@ class CLITestCase(unittest.TestCase):
             ])
             self.assertEqual(repository.changes_version(), "0.2.0")
             repository.perform([
-                EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should update the minor version"),
-                EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should not update the minor version"),
+                EmptyCommit("feat!: this breaking change should update the major version"),
+                EmptyCommit("feat!: this breaking change should not update the major version"),
             ])
             self.assertEqual(repository.changes_version(), "1.0.0")
 
@@ -193,7 +193,7 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("fix: this fix should not affect the released version"),
                 EmptyCommit("feat: this feat should not affect the released version"),
-                EmptyCommit("BREAKING CHANGE: this BREAKING CHANGE should not affect the released version"),
+                EmptyCommit("feat!: this breaking change should not affect the released version"),
             ])
             self.assertEqual(repository.changes_version(released=True), "2.1.3")
 


### PR DESCRIPTION
I misunderstood the Conventional Commits documentation and thought that 'BREAKING CHANGE' was a type. Instead, the keyword is meant to be used as a footer, or breaking changes indicated with a '!'. This removes the 'BREAKING CHANGE' type to avoid unnecessary confusion and improve conformance with Conventional Commits.