### PR TITLE
refactor: Rename Release.has_tag to Release.is_released

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -122,7 +122,7 @@ class Release(object):
     def __init__(self, version, changes):
         self.version = version
         self.changes = changes
-        self.has_tag = False  # TODO: Rename this to 'unreleased'
+        self.is_released = False
 
     def set_previous_version(self, previous_version):
         """Recomputes the current version based on the previous version by applying the changes in order."""
@@ -161,7 +161,7 @@ class History(object):
         for change in all_changes:
             if change.version is not None:
                 release = Release(change.version, [])
-                release.has_tag = True
+                release.is_released = True
                 releases.append(release)
             releases[-1].changes.append(change)
 
@@ -177,7 +177,7 @@ class History(object):
 
     def format_changes(self, skip_unreleased=False):
         releases = list(self.releases)
-        if skip_unreleased and not releases[0].has_tag:
+        if skip_unreleased and not releases[0].is_released:
             releases.pop(0)
         return format_releases(releases)
 
@@ -285,7 +285,7 @@ def format_changes(changes):
 
 def format_release(release):
     result = f"# {release.version}"
-    if not release.has_tag:
+    if not release.is_released:
         result = result + " (Unreleased)"
     result = result + "\n\n"
     result = result + format_changes(release.changes)
@@ -316,7 +316,7 @@ def command_version(options):
     releases = history.releases
     release = releases[0]
     if options.released:
-        release = next(release for release in releases if release.has_tag)
+        release = next(release for release in releases if release.is_released)
     print(release.version)
 
 
@@ -339,7 +339,7 @@ def command_current_notes(options):
 def command_release(options):
     history = History(scope=resolve_scope(options))
     releases = history.releases
-    if releases[0].has_tag or releases[0].is_empty:
+    if releases[0].is_released or releases[0].is_empty:
         # There aren't any unreleased versions.
         if options.skip_if_empty:
             exit()


### PR DESCRIPTION
The original name was somewhat misleading as it doesn't really capture the meaning of a tag, and when history augmentation is added, there's not guaranteed to be a tag.