### PR TITLE
feat: Customisable templates for rendering release notes

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -532,7 +532,7 @@ class AbsolutePathLoader(jinja2.BaseLoader):
     def get_source(self, environment, template):
         path = os.path.abspath(template)
         if not os.path.exists(path):
-            raise TemplateNotFound(path)
+            raise jinja2.TemplateNotFound(path)
         mtime = os.path.getmtime(path)
         with open(path) as f:
             source = f.read()

--- a/changes.py
+++ b/changes.py
@@ -549,7 +549,10 @@ class AbsolutePathLoader(jinja2.BaseLoader):
     cli.Argument("--template", help="custom Jinja2 template")
 ])
 def command_notes(options):
-    history = History(path=os.getcwd(), history=options.history, scope=resolve_scope(options), skip_unreleased=options.released)
+    history = History(path=os.getcwd(),
+                      history=options.history,
+                      scope=resolve_scope(options),
+                      skip_unreleased=options.released)
 
     if options.template is not None:
         template = os.path.abspath(options.template)

--- a/changes.py
+++ b/changes.py
@@ -458,6 +458,7 @@ def command_version(options):
     cli.Argument("--command", help="additional command to run to perform during the release; if the command fails, the release will be rolled back"),
     cli.Argument("--push", action="store_true", default=False, help="push the newly created tag"),
     cli.Argument("--dry-run", action="store_true", default=False, help="perform a dry run, only logging the operations that would be performed"),
+    cli.Argument("--template", help="custom Jinja2 template"),
 ])
 def command_release(options):
     history = History(path=os.getcwd(), scope=resolve_scope(options))
@@ -488,7 +489,11 @@ def command_release(options):
         logging.info("Running command...")
         success = True
 
-        notes = format_notes(releases=[releases[0]], template=SINGLE_RELEASE_TEMPLATE)
+        if options.template is not None:
+            template = os.path.abspath(options.template)
+        else:
+            template = SINGLE_RELEASE_TEMPLATE
+        notes = format_notes(releases=[releases[0]], template=template)
 
         # Create a temporary directory containing the notes.
         with tempfile.NamedTemporaryFile() as notes_file:

--- a/changes.py
+++ b/changes.py
@@ -37,6 +37,10 @@ import yaml
 import cli
 
 
+CHANGES_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_DIRECTORY = os.path.join(CHANGES_DIRECTORY, "templates")
+
+
 class Type(enum.Enum):
     CI = "ci"
     DOCUMENTATION = "docs"
@@ -418,39 +422,18 @@ def group_changes(changes):
     return results
 
 
-# TODO: Common import for the title?
 # TODO: Ensure we test unreleased with both change types
-# TODO: Move these into files.
+# TODO: Test the injected notes for the release process.
 
 
-ALL_NOTES_TEMPLATE = """
-{%- for release in releases -%}
-# {{ release.version }}{% if not release.is_released %} (Unreleased){% endif %}
-{% for section in release.sections %}
-**{{ section.title }}**
-
-{% for change in section.changes | reverse -%}
-- {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}
-{% endfor %}{% endfor %}
-{% endfor %}
-"""
-
-
-NOTES_TEMPLATE = """
-{%- for release in releases -%}
-{% for section in release.sections -%}
-**{{ section.title }}**
-
-{% for change in section.changes | reverse -%}
-- {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}
-{% endfor %}
-{% endfor %}
-{% endfor %}
-"""
+ALL_NOTES_TEMPLATE = "multiple.markdown"
+NOTES_TEMPLATE = "single.markdown"
 
 
 def format_changes(releases, template):
-    return jinja2.Template(template).render(releases=releases, Sections=Sections).rstrip() + "\n"
+    loader = jinja2.FileSystemLoader(TEMPLATES_DIRECTORY)
+    environment = jinja2.Environment(loader=loader)
+    return environment.get_template(template).render(releases=releases, Sections=Sections).rstrip() + "\n"
 
 
 def resolve_scope(options):

--- a/changes.py
+++ b/changes.py
@@ -243,6 +243,10 @@ class Section(object):
         self.type = type
         self.changes = changes
 
+    @property
+    def title(self):
+        return SECTION_TITLES[self.type]
+
 
 class History(object):
 
@@ -416,16 +420,14 @@ def group_changes(changes):
 
 # TODO: Common import for the title?
 # TODO: Ensure we test unreleased with both change types
+# TODO: Move these into files.
+
 
 ALL_NOTES_TEMPLATE = """
-{%- macro title(section) -%}
-{%- if section.type == Sections.CHANGES -%}Changes{%- elif section.type == Sections.FIXES -%}Fixes{%- endif -%}
-{%- endmacro -%}
-
-{% for release in releases -%}
+{%- for release in releases -%}
 # {{ release.version }}{% if not release.is_released %} (Unreleased){% endif %}
 {% for section in release.sections %}
-**{{ title(section) }}**
+**{{ section.title }}**
 
 {% for change in section.changes | reverse -%}
 - {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}
@@ -433,14 +435,11 @@ ALL_NOTES_TEMPLATE = """
 {% endfor %}
 """
 
-NOTES_TEMPLATE = """
-{%- macro title(section) -%}
-{%- if section.type == Sections.CHANGES -%}Changes{%- elif section.type == Sections.FIXES -%}Fixes{%- endif -%}
-{%- endmacro -%}
 
-{% for release in releases -%}
+NOTES_TEMPLATE = """
+{%- for release in releases -%}
 {% for section in release.sections -%}
-**{{ title(section) }}**
+**{{ section.title }}**
 
 {% for change in section.changes | reverse -%}
 - {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}

--- a/changes.py
+++ b/changes.py
@@ -425,10 +425,6 @@ def group_changes(changes):
     return results
 
 
-# TODO: Ensure we test unreleased with both change types
-# TODO: Test the injected notes for the release process.
-
-
 def format_notes(releases, template):
     loader = jinja2.ChoiceLoader([
         AbsolutePathLoader(),

--- a/templates/multiple.markdown
+++ b/templates/multiple.markdown
@@ -1,0 +1,9 @@
+{%- for release in releases -%}
+# {{ release.version }}{% if not release.is_released %} (Unreleased){% endif %}
+{% for section in release.sections %}
+**{{ section.title }}**
+
+{% for change in section.changes | reverse -%}
+- {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}
+{% endfor %}{% endfor %}
+{% endfor %}

--- a/templates/single.markdown
+++ b/templates/single.markdown
@@ -1,0 +1,9 @@
+{%- for release in releases -%}
+{% for section in release.sections -%}
+**{{ section.title }}**
+
+{% for change in section.changes | reverse -%}
+- {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/tests/common.py
+++ b/tests/common.py
@@ -167,13 +167,14 @@ class Repository(object):
             arguments.extend(["--released"])
         return self.changes(arguments).strip()
 
-
-    def changes_release(self, scope=None, command=None):
+    def changes_release(self, scope=None, command=None, template=None):
         arguments = ["release"]
         if scope is not None:
             arguments.extend(["--scope", scope])
         if command is not None:
             arguments.extend(["--command", command])
+        if template is not None:
+            arguments.extend(["--template", template])
         return self.changes(arguments)
 
     def changes_notes(self, released=False, all=False, history=None, scope=None):

--- a/tests/common.py
+++ b/tests/common.py
@@ -102,6 +102,10 @@ class Repository(object):
                 raise
             return result.stdout.decode("utf-8")
 
+    def read_file(self, path):
+        with open(os.path.join(self.path, path)) as fh:
+            return fh.read()
+
     def write_file(self, path, contents):
         with open(os.path.join(self.path, path), "w") as fh:
             fh.write(contents)
@@ -164,10 +168,12 @@ class Repository(object):
         return self.changes(arguments).strip()
 
 
-    def changes_release(self, scope=None):
+    def changes_release(self, scope=None, command=None):
         arguments = ["release"]
         if scope is not None:
             arguments.extend(["--scope", scope])
+        if command is not None:
+            arguments.extend(["--command", command])
         return self.changes(arguments)
 
     def changes_notes(self, released=False, all=False, history=None, scope=None):

--- a/tests/common.py
+++ b/tests/common.py
@@ -177,7 +177,7 @@ class Repository(object):
             arguments.extend(["--template", template])
         return self.changes(arguments)
 
-    def changes_notes(self, released=False, all=False, history=None, scope=None):
+    def changes_notes(self, released=False, all=False, history=None, scope=None, template=None):
         arguments = ["notes"]
         if released:
             arguments.append("--released")
@@ -187,6 +187,8 @@ class Repository(object):
             arguments.extend(["--history", history])
         if scope is not None:
             arguments.extend(["--scope", scope])
+        if template is not None:
+            arguments.extend(["--template", template])
         return self.changes(arguments)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,7 +223,7 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit"),
                 Tag("1.0.0")
             ])
-            self.assertEqual(repository.changes_notes(), "")
+            self.assertEqual(repository.changes_notes(), "\n")
             repository.perform([
                 EmptyCommit("fix: Doesn't crash"),
                 EmptyCommit("fix: Works"),
@@ -273,12 +273,12 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit"),
                 Tag("1.0.0")
             ])
-            self.assertEqual(repository.changes_notes(), "")
+            self.assertEqual(repository.changes_notes(), "\n")
             repository.perform([
                 EmptyCommit("fix: Doesn't crash"),
                 EmptyCommit("fix: Works"),
             ])
-            self.assertEqual(repository.changes_notes(released=True), "")
+            self.assertEqual(repository.changes_notes(released=True), "\n")
             repository.changes_release()
             self.assertEqual(repository.changes_notes(released=True),
 """**Fixes**
@@ -454,7 +454,6 @@ class CLITestCase(unittest.TestCase):
 - Foo
 
 # 1.10.1
-
 """)
 
     def test_notes_additional_history_ignoring_scope(self):
@@ -486,7 +485,6 @@ class CLITestCase(unittest.TestCase):
 - Foo
 
 # 1.0.0
-
 """)
 
             self.assertEqual(repository.changes_notes(all=True, released=True, history="history.yaml"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,6 +493,21 @@ class CLITestCase(unittest.TestCase):
 - Initial commit
 """)
 
+    def test_notes_template(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: Initial commit"),
+                Release(),
+                EmptyCommit("fix: Fix something"),
+                EmptyCommit("fix: Fix something else"),
+                Release(),
+                EmptyCommit("fix!: Fix something breaking compatibility"),
+                Release(),
+                EmptyCommit("feat: Unreleased feature"),
+            ])
+            repository.write_file("template.txt", "{{ releases | length }}")
+            self.assertEqual(repository.changes_notes(all=True, released=True, template="template.txt"), "3\n")
+
     def test_notes_additional_history_preserves_ordering(self):
         with Repository() as repository:
             repository.perform([

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -235,6 +235,70 @@ class CLITestCase(unittest.TestCase):
             repository.changes_release(command="echo $CHANGES_TITLE >> output.txt")
             self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
 
+    def test_release_command_environment_tag(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+            ])
+            repository.changes_release(command="echo $CHANGES_TAG >> output.txt")
+            self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
+
+    def test_release_command_environment_notes(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+            ])
+            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
+            self.assertEqual(repository.read_file("output.txt"),
+"""**Changes**
+
+- New feature
+
+""")
+            repository.perform([
+                EmptyCommit("fix: Improved something"),
+            ])
+            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
+            self.assertEqual(repository.read_file("output.txt"),
+"""**Changes**
+
+- New feature
+
+**Fixes**
+
+- Improved something
+
+""")
+
+    def test_release_command_environment_notes_changes(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+            ])
+            repository.changes_release(command="cat \"$CHANGES_NOTES_FILE\" > output.txt")
+            self.assertEqual(repository.read_file("output.txt"),
+"""**Changes**
+
+- New feature
+""")
+
+    def test_release_command_environment_notes_changes_and_fixes(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+                EmptyCommit("fix: Improved something"),
+            ])
+            repository.changes_release(command="cat \"$CHANGES_NOTES_FILE\" > output.txt")
+            self.assertEqual(repository.read_file("output.txt"),
+"""**Changes**
+
+- New feature
+
+**Fixes**
+
+- Improved something
+""")
+
     def test_current_notes(self):
         with Repository() as repository:
             repository.perform([

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,16 +248,17 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="echo -n \"$CHANGES_NOTES\" >> output.txt")
+            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
 - New feature
+
 """)
             repository.perform([
                 EmptyCommit("fix: Improved something"),
             ])
-            repository.changes_release(command="echo -n \"$CHANGES_NOTES\" >> output.txt")
+            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
@@ -266,6 +267,7 @@ class CLITestCase(unittest.TestCase):
 **Fixes**
 
 - Improved something
+
 """)
 
     def test_release_command_environment_notes_changes(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,6 +217,24 @@ class CLITestCase(unittest.TestCase):
             with self.assertRaises(subprocess.CalledProcessError):
                 repository.changes_release()
 
+    # TODO: Add scope in here too.
+
+    def test_release_command_environment_version(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+            ])
+            repository.changes_release(command="echo $CHANGES_VERSION >> output.txt")
+            self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
+
+    def test_release_command_environment_title(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+            ])
+            repository.changes_release(command="echo $CHANGES_TITLE >> output.txt")
+            self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
+
     def test_current_notes(self):
         with Repository() as repository:
             repository.perform([

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,17 +248,16 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
+            repository.changes_release(command="echo -n \"$CHANGES_NOTES\" >> output.txt")
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
 - New feature
-
 """)
             repository.perform([
                 EmptyCommit("fix: Improved something"),
             ])
-            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
+            repository.changes_release(command="echo -n \"$CHANGES_NOTES\" >> output.txt")
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
@@ -267,7 +266,6 @@ class CLITestCase(unittest.TestCase):
 **Fixes**
 
 - Improved something
-
 """)
 
     def test_release_command_environment_notes_changes(self):
@@ -298,6 +296,16 @@ class CLITestCase(unittest.TestCase):
 
 - Improved something
 """)
+
+    def test_release_command_environment_notes_template(self):
+        with Repository() as repository:
+            repository.perform([
+                EmptyCommit("feat: New feature"),
+                EmptyCommit("fix: Improved something"),
+            ])
+            repository.write_file("template.txt", "{{ releases | length }}")
+            repository.changes_release(command="cat \"$CHANGES_NOTES_FILE\" > output.txt", template="template.txt")
+            self.assertEqual(repository.read_file("output.txt"), "1\n")
 
     def test_current_notes(self):
         with Repository() as repository:


### PR DESCRIPTION
This change switches to Jinja2 for rendering the release notes instead of hand-crafted string manipulation. It introduces two default templates (one for single release release notes, and one for multiple release release notes). It also introduces a parameter to the `notes` command that allows users to override these templates and provide their own.