### PR TITLE
feat: Pass CHANGES_PRERELEASE environment variable to release commands

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -94,6 +94,7 @@ class Repository(object):
             kwargs = {}
             if env is not None:
                 kwargs["env"] = env
+            logging.debug(command)
             result = subprocess.run(command, capture_output=True, **kwargs)
             try:
                 result.check_returncode()
@@ -106,12 +107,19 @@ class Repository(object):
         with open(os.path.join(self.path, path)) as fh:
             return fh.read()
 
-    def write_file(self, path, contents):
-        with open(os.path.join(self.path, path), "w") as fh:
+    def write_file(self, path, contents, mode=0):
+        file_path = os.path.join(self.path, path)
+        with open(file_path, "w") as fh:
             fh.write(contents)
+        if mode:
+            os.chmod(file_path, mode)
+        return file_path
+
+    def write_bash_script(self, path, contents):
+        return self.write_file(path, "#!/bin/bash\n" + contents, 0o744)
 
     def write_yaml(self, path, contents):
-        self.write_file(path, yaml.dump(contents))
+        return self.write_file(path, yaml.dump(contents))
 
     def git(self, arguments):
         return self.run(["git"] + arguments)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -92,6 +92,15 @@ class VersionTestCase(unittest.TestCase):
         self.assertNotEqual([str(version) for version in input_versions], output)
         self.assertEqual([str(version) for version in sorted(input_versions)], output)
 
+    def test_prerelease(self):
+        self.assertTrue(Version().is_prerelease)
+        self.assertTrue(Version(0, 1, 4).is_prerelease)
+        self.assertTrue(Version(0, 0, 1).is_prerelease)
+        self.assertTrue(Version(0, 20, 0).is_prerelease)
+        self.assertFalse(Version(1, 0, 0).is_prerelease)
+        self.assertFalse(Version(200, 1, 0).is_prerelease)
+        self.assertFalse(Version(2, 0, 10).is_prerelease)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some release tools (looking at you GitHub) require releases to be explicitly marked as prerelease. This change introduces an additional environment variable (`CHANGES_PRERELEASE`) which can be inspected to determine if the version is prerelease or not (major version 0). It also introduces unit tests and some explicit tests for the shell being used to execute commands.