### PR TITLE
fix: Relax the unbound constraint on the example GitHub release script

### DIFF
--- a/examples/gh-release.sh
+++ b/examples/gh-release.sh
@@ -23,7 +23,6 @@
 set -e
 set -o pipefail
 set -x
-set -u
 
 # Actually make the release.
 FLAGS=()


### PR DESCRIPTION
This causes the array evaluation to fail if it's empty (when it's not a prerelease build) and is not as necessary as the script is fairly short and easy to audit.