### PR TITLE
feat: Support running an executable during release

### DIFF
--- a/cheese/foo.sh
+++ b/cheese/foo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$@"

--- a/tests/common.py
+++ b/tests/common.py
@@ -165,7 +165,10 @@ class Repository(object):
     def changes(self, arguments=[]):
         environment = dict(os.environ)
         environment["PATH"] = environment["PATH"] + ":" + ROOT_DIRECTORY
-        return self.run(["changes"] + arguments, env=environment)
+        if debug:
+            arguments = ["--verbose"] + arguments
+        command = ["changes"] + arguments
+        return self.run(command, env=environment)
 
     def changes_version(self, scope=None, released=False):
         arguments = ["version"]


### PR DESCRIPTION
This introduces a way to call an executable during the release process (instead of running an inline script). This vastly simplifies the process of handling arguments as there's no need to delimit `"$@"` in the inline script (it's just implicit).