### PR TITLE
test: Remove the dedicated changes_release test wrapper

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -71,7 +71,7 @@ class Tag(object):
 class Release(object):
 
     def perform(self, repository):
-        repository.changes_release()
+        repository.changes(["release"])
 
 
 class Repository(object):
@@ -169,16 +169,6 @@ class Repository(object):
             arguments = ["--verbose"] + arguments
         command = ["changes"] + arguments
         return self.run(command, env=environment)
-
-    def changes_release(self, scope=None, command=None, template=None, arguments=[]):
-        changes_arguments = ["release"]
-        if scope is not None:
-            changes_arguments.extend(["--scope", scope])
-        if command is not None:
-            changes_arguments.extend(["--command", command])
-        if template is not None:
-            changes_arguments.extend(["--template", template])
-        return self.changes(changes_arguments + arguments)
 
     def changes_notes(self, released=False, all=False, history=None, scope=None, template=None):
         arguments = ["notes"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,7 +200,7 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("feat: feature"),
             ])
             with self.assertRaises(subprocess.CalledProcessError):
-                repository.changes_release(command="exit 1")
+                repository.changes(["release", "--command", "exit 1"])
             self.assertEqual(repository.tag(), [])
 
     def test_release_tag_push_cleanup_on_failure(self):
@@ -253,7 +253,7 @@ class CLITestCase(unittest.TestCase):
             script_path = repository.write_file("script.sh", """#!/bin/bash
 ps h -p $$ -o args='' | cut -f1 -d' ' > output.txt
 """, mode=0o744)
-            repository.changes_release(command=script_path)
+            repository.changes(["release", "--command", script_path])
             self.assertEqual(repository.read_file("output.txt").strip(), "/bin/bash")
 
     def test_release_command_bash_script_correct_echo(self):
@@ -262,7 +262,7 @@ ps h -p $$ -o args='' | cut -f1 -d' ' > output.txt
                 EmptyCommit("feat: feature"),
             ])
             script_path = repository.write_bash_script("script.sh", "echo -n Foo > output.txt")
-            repository.changes_release(command=script_path)
+            repository.changes(["release", "--command", script_path])
             self.assertEqual(repository.read_file("output.txt"), "Foo")
 
     def test_release_command_and_exec_fails(self):
@@ -320,15 +320,15 @@ else
 echo -n "release" > output.txt
 fi
 """)
-            repository.changes_release(command=script_path)
+            repository.changes(["release", "--command", script_path])
             self.assertEqual(repository.read_file("output.txt"), "prerelease")
 
             repository.perform([EmptyCommit("fix: minor fix")])
-            repository.changes_release(command=script_path)
+            repository.changes(["release", "--command", script_path])
             self.assertEqual(repository.read_file("output.txt"), "prerelease")
 
             repository.perform([EmptyCommit("feat!: initial release")])
-            repository.changes_release(command=script_path)
+            repository.changes(["release", "--command", script_path])
             self.assertEqual(repository.read_file("output.txt"), "release")
 
     def test_release_command_environment_title(self):
@@ -344,7 +344,7 @@ fi
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="echo $CHANGES_TAG >> output.txt")
+            repository.changes(["release", "--command", "echo $CHANGES_TAG >> output.txt"])
             self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
 
     def test_release_command_environment_tag_with_scope(self):
@@ -368,7 +368,7 @@ fi
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
+            repository.changes(["release", "--command", "echo \"$CHANGES_NOTES\" >> output.txt"])
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
@@ -378,7 +378,7 @@ fi
             repository.perform([
                 EmptyCommit("fix: Improved something"),
             ])
-            repository.changes_release(command="echo \"$CHANGES_NOTES\" >> output.txt")
+            repository.changes(["release", "--command", "echo \"$CHANGES_NOTES\" >> output.txt"])
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
@@ -395,7 +395,7 @@ fi
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="cat \"$CHANGES_NOTES_FILE\" > output.txt")
+            repository.changes(["release", "--command", "cat \"$CHANGES_NOTES_FILE\" > output.txt"])
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
@@ -408,7 +408,7 @@ fi
                 EmptyCommit("feat: New feature"),
                 EmptyCommit("fix: Improved something"),
             ])
-            repository.changes_release(command="cat \"$CHANGES_NOTES_FILE\" > output.txt")
+            repository.changes(["release", "--command", "cat \"$CHANGES_NOTES_FILE\" > output.txt"])
             self.assertEqual(repository.read_file("output.txt"),
 """**Changes**
 
@@ -435,7 +435,7 @@ fi
                 EmptyCommit("feat: New feature"),
                 EmptyCommit("fix: Improved something"),
             ])
-            repository.changes_release(command="echo \"$@\" > output.txt", arguments=["a"])
+            repository.changes(["release", "--command", "echo \"$@\" > output.txt", "a"])
             self.assertEqual(repository.read_file("output.txt"), "a\n")
 
     def test_release_command_multiple_arguments(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,7 +116,7 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("feat!: Breaking feat should increment major version"),
             ])
             self.assertEqual(repository.changes(["version"]).strip(), "1.0.0")
-            repository.changes_release()
+            repository.changes(["release"])
             repository.perform([
                 EmptyCommit("fix!: Breaking fix should increment major version"),
             ])
@@ -162,7 +162,7 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat: feature"),
             ])
-            repository.changes_release()
+            repository.changes(["release"])
             self.assertEqual(repository.tag(), ["0.1.0"])
 
     def test_release_tag_push(self):
@@ -186,7 +186,7 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat: another feature"),
             ])
-            repository.changes_release()
+            repository.changes(["release"])
             self.assertEqual(sorted(repository.tag()), ["0.1.0", "cheese_0.1.0"])
             repository.perform([
                 EmptyCommit("fix(cheese): fixed something"),
@@ -218,7 +218,7 @@ class CLITestCase(unittest.TestCase):
     def test_release_fails_empty_repository(self):
         with Repository() as repository:
             with self.assertRaises(subprocess.CalledProcessError):
-                repository.changes_release()
+                repository.changes(["release"])
 
     def test_release_fails_without_changes(self):
         with Repository() as repository:
@@ -227,7 +227,7 @@ class CLITestCase(unittest.TestCase):
                 Tag("0.1.1")
             ])
             with self.assertRaises(subprocess.CalledProcessError):
-                repository.changes_release()
+                repository.changes(["release"])
 
     def test_release_fails_without_changes_or_previous_release(self):
         with Repository() as repository:
@@ -235,7 +235,7 @@ class CLITestCase(unittest.TestCase):
                 EmptyCommit("initial commit with no changes"),
             ])
             with self.assertRaises(subprocess.CalledProcessError):
-                repository.changes_release()
+                repository.changes(["release"])
 
     def test_release_command_default_interpreter(self):
         with Repository() as repository:
@@ -478,7 +478,7 @@ fi
 - Doesn't crash
 - Works
 """)
-            repository.changes_release()
+            repository.changes(["release"])
             self.assertEqual(repository.changes_notes(),
 """**Changes**
 
@@ -510,7 +510,7 @@ fi
                 EmptyCommit("fix: Works"),
             ])
             self.assertEqual(repository.changes_notes(released=True), "\n")
-            repository.changes_release()
+            repository.changes(["release"])
             self.assertEqual(repository.changes_notes(released=True),
 """**Fixes**
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,7 +181,7 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat(cheese): feature"),
             ])
-            repository.changes_release(scope="cheese")
+            repository.changes(["release", "--scope", "cheese"])
             self.assertEqual(repository.tag(), ["cheese_0.1.0"])
             repository.perform([
                 EmptyCommit("feat: another feature"),
@@ -242,7 +242,7 @@ class CLITestCase(unittest.TestCase):
             repository.perform([
                 EmptyCommit("feat: feature"),
             ])
-            repository.changes_release(command="ps h -p $$ -o args='' | cut -f1 -d' ' > output.txt")
+            repository.changes(["release", "--command", "ps h -p $$ -o args='' | cut -f1 -d' ' > output.txt"])
             self.assertEqual(repository.read_file("output.txt").strip(), "/bin/sh")
 
     def test_release_command_bash_script(self):
@@ -298,7 +298,7 @@ ps h -p $$ -o args='' | cut -f1 -d' ' > output.txt
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="echo $CHANGES_VERSION >> output.txt")
+            repository.changes(["release", "--command", "echo $CHANGES_VERSION >> output.txt"])
             self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
 
     def test_release_exec_environment_version(self):
@@ -336,7 +336,7 @@ fi
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(command="echo $CHANGES_TITLE >> output.txt")
+            repository.changes(["release", "--command", "echo $CHANGES_TITLE >> output.txt"])
             self.assertEqual(repository.read_file("output.txt"), "0.1.0\n")
 
     def test_release_command_environment_tag(self):
@@ -352,7 +352,7 @@ fi
             repository.perform([
                 EmptyCommit("feat: New feature"),
             ])
-            repository.changes_release(scope="scope", command="echo $CHANGES_TAG >> output.txt")
+            repository.changes(["release", "--scope", "scope", "--command", "echo $CHANGES_TAG >> output.txt"])
             self.assertEqual(repository.read_file("output.txt"), "scope_0.1.0\n")
 
     def test_release_command_environment_tag_with_scope_legacy_argument(self):
@@ -426,7 +426,7 @@ fi
                 EmptyCommit("fix: Improved something"),
             ])
             repository.write_file("template.txt", "{{ releases | length }}")
-            repository.changes_release(command="cat \"$CHANGES_NOTES_FILE\" > output.txt", template="template.txt")
+            repository.changes(["release", "--command", "cat \"$CHANGES_NOTES_FILE\" > output.txt", "--template", "template.txt"])
             self.assertEqual(repository.read_file("output.txt"), "1\n")
 
     def test_release_command_single_argument(self):
@@ -445,7 +445,7 @@ fi
                 EmptyCommit("fix: Improved something"),
             ])
             script_path = repository.write_bash_script("count.sh", """printf '%s\n' "$@" > output.txt""")
-            repository.changes_release(command=f'{script_path} "$@"', arguments=["a", "b", "c d e"])
+            repository.changes(["release", "--command", f'{script_path} "$@"', "a", "b", "c d e"])
             self.assertEqual(repository.read_file("output.txt"), "a\nb\nc d e\n")
 
     def test_current_notes(self):


### PR DESCRIPTION
This wrapper was unnecessary and indirected the command line interface that is actually being tested.