### PR TITLE
fix!: Rename `CHANGES_PRERELEASE` to `CHANGES_INITIAL_DEVELOPMENT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ git clone git@github.com:jbmorley/changes.git
 cd changes
 pipenv install
 ```
+
+## Usage
+
+```bash
+changes --help
+```
+
+You can also find out details of specific sub-commands by passing the `--help` flag directly to those commands. For example,
+
+```bash
+changes release --help
+```
+
+## Development
+
+### Tests
+
+Run tests locally using the `test.sh` script:
+
+```bash
+./scripts/test.sh
+```

--- a/cli.py
+++ b/cli.py
@@ -30,10 +30,12 @@ COMMANDS = {}
 
 class Command(object):
 
-    def __init__(self, name, help, arguments, callback):
+    def __init__(self, name, help, arguments, epilog, formatter_class, callback):
         self.name = name
         self.help = help
         self.arguments = arguments
+        self.epilog = epilog
+        self.formatter_class = formatter_class
         self.callback = callback
 
 class Argument(object):
@@ -43,12 +45,12 @@ class Argument(object):
         self.kwargs = kwargs
 
 
-def command(name, help="", arguments=[]):
+def command(name, help="", arguments=[], epilog=None, formatter_class=argparse.HelpFormatter):
     def wrapper(fn):
         @functools.wraps(fn)
         def inner(*args, **kwargs):
             return fn(*args, **kwargs)
-        COMMANDS[name] = Command(name, help, arguments, inner)
+        COMMANDS[name] = Command(name, help, arguments, epilog, formatter_class, inner)
         return inner
     return wrapper
 
@@ -59,7 +61,10 @@ class CommandParser(object):
         self.parser = argparse.ArgumentParser(*args, **kwargs)
         subparsers = self.parser.add_subparsers(help="command")
         for name, command in COMMANDS.items():
-            subparser = subparsers.add_parser(command.name, help=command.help)
+            subparser = subparsers.add_parser(command.name,
+                                              help=command.help,
+                                              epilog=command.epilog,
+                                              formatter_class=command.formatter_class)
             for argument in command.arguments:
                 subparser.add_argument(*(argument.args), **(argument.kwargs))
             subparser.set_defaults(fn=command.callback)

--- a/examples/gh-release.sh
+++ b/examples/gh-release.sh
@@ -26,7 +26,7 @@ set -x
 
 # Actually make the release.
 FLAGS=()
-if $CHANGES_PRERELEASE ; then
+if $CHANGES_INITIAL_DEVELOPMENT ; then
     FLAGS+=("--prerelease")
 fi
 gh release create "$CHANGES_TAG" --title "$CHANGES_TITLE" --notes-file "$CHANGES_NOTES_FILE" "${FLAGS[@]}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,7 +350,7 @@ ps h -p $$ -o args='' | cut -f1 -d' ' > output.txt
         with Repository() as repository:
             repository.perform([EmptyCommit("feat: initial commit")])
             script_path = repository.write_bash_script("script.sh", """
-if $CHANGES_PRERELEASE ; then
+if $CHANGES_INITIAL_DEVELOPMENT ; then
 echo -n "prerelease" > output.txt
 else
 echo -n "release" > output.txt

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -92,14 +92,14 @@ class VersionTestCase(unittest.TestCase):
         self.assertNotEqual([str(version) for version in input_versions], output)
         self.assertEqual([str(version) for version in sorted(input_versions)], output)
 
-    def test_prerelease(self):
-        self.assertTrue(Version().is_prerelease)
-        self.assertTrue(Version(0, 1, 4).is_prerelease)
-        self.assertTrue(Version(0, 0, 1).is_prerelease)
-        self.assertTrue(Version(0, 20, 0).is_prerelease)
-        self.assertFalse(Version(1, 0, 0).is_prerelease)
-        self.assertFalse(Version(200, 1, 0).is_prerelease)
-        self.assertFalse(Version(2, 0, 10).is_prerelease)
+    def test_initial_development(self):
+        self.assertTrue(Version().initial_development)
+        self.assertTrue(Version(0, 1, 4).initial_development)
+        self.assertTrue(Version(0, 0, 1).initial_development)
+        self.assertTrue(Version(0, 20, 0).initial_development)
+        self.assertFalse(Version(1, 0, 0).initial_development)
+        self.assertFalse(Version(200, 1, 0).initial_development)
+        self.assertFalse(Version(2, 0, 10).initial_development)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a preparatory change in advance of adding support for SemVer pre-release versioning. Since--under-the-hood--the `CHANGES_PRERELEASE` environment variable was checking to see if the major version is greater than 0, it has been renamed to 'initial development' correspond with SemVer's conventions (see https://semver.org/#spec-item-4). 'Unstable' was considered, but this seems less explicit and might not correctly represent all projects in the pre-1.0.0 state.