### PR TITLE
fix: Name the Pipenv source

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,8 +1,8 @@
 [[source]]
 
+name = "pypi"
 url = "https://pypi.python.org/simple"
 verify_ssl = true
-
 
 [packages]
 


### PR DESCRIPTION
This is now required.