### PR TITLE
ci: Update GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
       run: scripts/build.sh
 
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -84,7 +84,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
- `actions/checkout`: `v4` → `v6`
- `actions/upload-artifact`: `v4` → `v7`
- `actions/download-artifact`: `v4` → `v8`